### PR TITLE
Fix pull request event using Head repo name instead of Base

### DIFF
--- a/ci-tools/utils/http.go
+++ b/ci-tools/utils/http.go
@@ -37,7 +37,7 @@ func SendUploadRequest(url string, reader io.Reader, headers *map[string]string)
 	resp, err := HttpDo("POST", url, reader, headers)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to upload: %s", err)
+		return nil, fmt.Errorf("failed to upload: %w", err)
 	}
 
 	if resp != nil {

--- a/github/ghevents/pullrequest.go
+++ b/github/ghevents/pullrequest.go
@@ -35,7 +35,7 @@ func synchronizePR(payload *github.PullRequestEvent) (*awstypes.Response, error)
 			PullRequestID:     *data.ID,
 			PullRequestNumber: *data.Number,
 			OwnerName:         *data.Base.Repo.Owner.Login,
-			RepoName:          *data.Head.Repo.Name,
+			RepoName:          *data.Base.Repo.Name,
 			EntryDate:         time.Now(),
 		}
 		err = models.PullRequestTable().Put(pr).Run()

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,9 @@ require (
 	github.com/aws/aws-lambda-go v1.10.0
 	github.com/aws/aws-sdk-go v1.19.38
 	github.com/bradleyfalzon/ghinstallation v1.1.1
-	github.com/fnproject/fdk-go v0.0.2
 	github.com/google/go-github/v32 v32.1.0
 	github.com/guregu/dynamo v1.2.1
 	github.com/sirupsen/logrus v1.5.0
 	github.com/stretchr/testify v1.3.0
-	github.com/tencentyun/scf-go-lib v0.0.0-20200624065115-ba679e2ec9c9
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/fnproject/fdk-go v0.0.2 h1:nebofQYAY8SbcjqmoaBo6KLNTwUrJq6lGdi7RCbq/EA=
-github.com/fnproject/fdk-go v0.0.2/go.mod h1:9m+nEyku9SqJAVJQsfZOZBQzFkCs+jvmbZJhvgDX4ts=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
@@ -40,8 +38,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/tencentyun/scf-go-lib v0.0.0-20200624065115-ba679e2ec9c9 h1:JdeXp/XPi7lBmpQNSUxElMAvwppMlFSiamTtXYRFuUc=
-github.com/tencentyun/scf-go-lib v0.0.0-20200624065115-ba679e2ec9c9/go.mod h1:K3DbqPpP2WE/9MWokWWzgFZcbgtMb9Wd5CYk9AAbEN8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
This issue would prevent the bot from managing to send a comment if the Head repository (e.g. fork) was of an other name than the Base repository.